### PR TITLE
old syntax was changed for list comprehension so that library can be used in the current version

### DIFF
--- a/lib/mustache/dynamo/mustache_handler.ex
+++ b/lib/mustache/dynamo/mustache_handler.ex
@@ -63,11 +63,11 @@ if Enum.all? [Dynamo.Templates.Handler, Dynamo.Template], &Code.ensure_loaded?(&
     end
 
     defp vars(locals) do
-      lc name inlist locals, do: { name, [], nil }
+      for name <- locals, do: { name, [], nil }
     end
 
     defp match(locals) do
-      lc var inlist locals, do: { :=, [], [{ :_, [], nil }, var] }
+      for var <- locals, do: { :=, [], [{ :_, [], nil }, var] }
     end
   end
 end

--- a/lib/mustache/utils.ex
+++ b/lib/mustache/utils.ex
@@ -87,7 +87,7 @@ defmodule Mustache.Utils do
     { '>',  '&gt;' },
   ]
 
-  lc { k, v } inlist @table_for_escape_html do
+  for { k, v } <- @table_for_escape_html do
     defp escape_html(unquote(k) ++ t, acc) do
       escape_html(t, unquote(Enum.reverse(v)) ++ acc)
     end


### PR DESCRIPTION
if you want you could just merge
