### PR TITLE
binary_to_atom and list_to_atom no longer exist in the global kernel mod...

### DIFF
--- a/lib/mustache/mix/tasks/spec.generate.ex
+++ b/lib/mustache/mix/tasks/spec.generate.ex
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Spec.Generate do
   end
 
   def to_keyword({ key, value }) when is_binary(key) do
-    { binary_to_atom(key), to_keyword(value) }
+    { String.to_atom(key), to_keyword(value) }
   end
 
   def to_keyword(other), do: other

--- a/lib/mustache/tokenizer.ex
+++ b/lib/mustache/tokenizer.ex
@@ -71,7 +71,7 @@ defmodule Mustache.Tokenizer do
       var == :. ->
         tokenize(rest, tags, new_line, new_line, [], [{ :unescaped_dot, line, var } | acc])
       to_string(var) =~ ~r/^\w+(\.\w+)+$/ ->
-        atoms = to_string(var) |> String.split(".") |> Enum.map(&binary_to_atom(&1))
+        atoms = to_string(var) |> String.split(".") |> Enum.map(&String.to_atom(&1))
         tokenize(rest, tags, new_line, new_line, [], [{ :unescaped_dotted_name, line, atoms } | acc])
       true ->
         tokenize(rest, tags, new_line, new_line, [], [{ :unescaped_variable, line, var } | acc])
@@ -97,7 +97,7 @@ defmodule Mustache.Tokenizer do
       var == :. ->
         tokenize(rest, tags, new_line, new_line, [], [{ :unescaped_dot, line, var } | acc])
       to_string(var) =~ ~r/^\w+(\.\w+)+$/ ->
-        atoms = to_string(var) |> String.split(".") |> Enum.map(&binary_to_atom(&1))
+        atoms = to_string(var) |> String.split(".") |> Enum.map(&String.to_atom(&1))
         tokenize(rest, tags, new_line, new_line, [], [{ :unescaped_dotted_name, line, atoms } | acc])
       true ->
         tokenize(rest, tags, new_line, new_line, [], [{ :unescaped_variable, line, var } | acc])
@@ -113,7 +113,7 @@ defmodule Mustache.Tokenizer do
     maybe_line_break = if line_break_flg, do: [:line_break], else: []
 
     if to_string(var) =~ ~r/^\w+(\.\w+)+$/ do
-      atoms = to_string(var) |> String.split(".") |> Enum.map(&binary_to_atom(&1))
+      atoms = to_string(var) |> String.split(".") |> Enum.map(&String.to_atom(&1))
       tokenize(rest, tags, new_line, new_line, [], maybe_line_break ++ [{ :dotted_name_section, line, atoms } | acc])
     else
       tokenize(rest, tags, new_line, new_line, [], maybe_line_break ++ [{ :section, line, var } | acc])
@@ -129,7 +129,7 @@ defmodule Mustache.Tokenizer do
     maybe_line_break = if line_break_flg, do: [:line_break], else: []
 
     if to_string(var) =~ ~r/^\w+(\.\w+)+$/ do
-      atoms = to_string(var) |> String.split(".") |> Enum.map(&binary_to_atom(&1))
+      atoms = to_string(var) |> String.split(".") |> Enum.map(&String.to_atom(&1))
       tokenize(rest, tags, new_line, new_line, [], maybe_line_break ++ [{ :dotted_name_inverted_section, line, atoms } | acc])
     else
       tokenize(rest, tags, new_line, new_line, [], maybe_line_break ++ [{ :inverted_section, line, var } | acc])
@@ -145,7 +145,7 @@ defmodule Mustache.Tokenizer do
     maybe_line_break = if line_break_flg, do: [:line_break], else: []
 
     if to_string(var) =~ ~r/^\w+(\.\w+)+$/ do
-      atoms = to_string(var) |> String.split(".") |> Enum.map(&binary_to_atom(&1))
+      atoms = to_string(var) |> String.split(".") |> Enum.map(&String.to_atom(&1))
       tokenize(rest, tags, new_line, new_line, [], maybe_line_break ++ [{ :end_section, line, atoms } | acc])
     else
       tokenize(rest, tags, new_line, new_line, [], maybe_line_break ++ [{ :end_section, line, var } | acc])
@@ -172,7 +172,7 @@ defmodule Mustache.Tokenizer do
       var == :. ->
         tokenize(rest, tags, new_line, new_line, [], [{ :dot, line, var } | acc])
       to_string(var) =~ ~r/^\w+(\.\w+)+$/ ->
-        atoms = to_string(var) |> String.split(".") |> Enum.map(&binary_to_atom(&1))
+        atoms = to_string(var) |> String.split(".") |> Enum.map(&String.to_atom(&1))
         tokenize(rest, tags, new_line, new_line, [], [{ :dotted_name, line, atoms } | acc])
       true ->
         tokenize(rest, tags, new_line, new_line, [], [{ :variable, line, var } | acc])
@@ -242,13 +242,13 @@ defmodule Mustache.Tokenizer do
           _ when buffer == [] ->
             raise SyntaxError, line: line, description: "No contents in tag"
           [?\r,?\n|t] when ignore_break_flg ->
-            { buffer |> Enum.reverse |> list_to_atom, line, t, true }
+            { buffer |> Enum.reverse |> List.to_atom, line, t, true }
           [?\n|t] when ignore_break_flg ->
-            { buffer |> Enum.reverse |> list_to_atom, line, t, true }
+            { buffer |> Enum.reverse |> List.to_atom, line, t, true }
           [] when ignore_break_flg ->
-            { buffer |> Enum.reverse |> list_to_atom, line, '', true }
+            { buffer |> Enum.reverse |> List.to_atom, line, '', true }
           t ->
-            { buffer |> Enum.reverse |> list_to_atom, line, t, false }
+            { buffer |> Enum.reverse |> List.to_atom, line, t, false }
         end
       _ ->
         case string do

--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,7 @@ defmodule Mustache.Mixfile do
   def project do
     [ app: :mustache,
       version: "0.0.1",
+      elixir: "~> 1.0.0-rc2",
       deps: deps(Mix.env) ]
   end
 


### PR DESCRIPTION
...ule

The have been replaced with String.to_atom and List.to_atom
