### PR TITLE
Warning fixes

### DIFF
--- a/lib/mustache/compiler.ex
+++ b/lib/mustache/compiler.ex
@@ -187,7 +187,12 @@ defmodule Mustache.Compiler do
     quote do
       var = unquote(var)
 
-      if is_function(var, 0), do: var = var.()
+      var =
+        if is_function(var, 0) do
+         var.()
+        else
+          var
+        end
 
       unquote(buffer) <> Mustache.Utils.escape_html(Mustache.Utils.to_binary(var))
     end
@@ -197,7 +202,12 @@ defmodule Mustache.Compiler do
     quote do
       var = unquote(var)
 
-      if is_function(var, 0), do: var = var.()
+      var =
+        if is_function(var, 0) do
+         var.()
+        else
+          var
+        end
 
       unquote(buffer) <> Mustache.Utils.to_binary(var)
     end
@@ -207,7 +217,12 @@ defmodule Mustache.Compiler do
     quote do
       var = adding = Mustache.Utils.recur_access(unquote(var), unquote(atoms))
 
-      if is_function(var, 0), do: var = var.()
+      var =
+        if is_function(var, 0) do
+         var.()
+        else
+          var
+        end
 
       unquote(buffer) <> Mustache.Utils.escape_html(Mustache.Utils.to_binary(var))
     end
@@ -217,7 +232,12 @@ defmodule Mustache.Compiler do
     quote do
       var = Mustache.Utils.recur_access(unquote(var), unquote(atoms))
 
-      if is_function(var, 0), do: var = var.()
+      var =
+        if is_function(var, 0) do
+         var.()
+        else
+          var
+        end
 
       unquote(buffer) <> Mustache.Utils.to_binary(var)
     end

--- a/lib/mustache/tokenizer.ex
+++ b/lib/mustache/tokenizer.ex
@@ -66,7 +66,6 @@ defmodule Mustache.Tokenizer do
   defp tokenize_mustache(t, { _, ctag } = tags, current_line, line, buffer, acc) do
     acc = tokenize_text(current_line, buffer, acc)
     { var, new_line, rest, _ } = tokenize_variable(t, [?}|ctag] , line, [])
-
     cond do
       var == :. ->
         tokenize(rest, tags, new_line, new_line, [], [{ :unescaped_dot, line, var } | acc])
@@ -274,7 +273,7 @@ defmodule Mustache.Tokenizer do
   end
 
   defp strip_space([]), do: raise(SyntaxError, description: "Unclosed tag")
-  defp strip_space([? |t]), do: t
+  defp strip_space([?\s |t]), do: t
   defp strip_space(string), do: string
 
   defp tokenize_new_otag(string, buffer, finish_flg \\ false)
@@ -283,7 +282,7 @@ defmodule Mustache.Tokenizer do
     raise SyntaxError, description: "Unclosed tag"
   end
 
-  defp tokenize_new_otag([? |t], buffer, _finish_flg) do
+  defp tokenize_new_otag([?\s |t], buffer, _finish_flg) do
     tokenize_new_otag(t, buffer, true)
   end
 
@@ -311,7 +310,7 @@ defmodule Mustache.Tokenizer do
       _ ->
         case string do
           [] -> raise SyntaxError, description: "Unclosed tag"
-          [? |t] ->
+          [?\s |t] ->
             tokenize_new_ctag(t, ctag, buffer, ignore_break_flg)
           [h|t] ->
             tokenize_new_ctag(t, ctag, [h|buffer], ignore_break_flg)
@@ -325,7 +324,7 @@ defmodule Mustache.Tokenizer do
   defp tokenize_text(line, buffer, acc, ignore_tail_whitespaces_flg \\ false)
 
   defp tokenize_text(line, buffer, acc, true) do
-    [ { :text, line, String.rstrip(:unicode.characters_to_binary(Enum.reverse(buffer)), ? ) } | acc]
+    [ { :text, line, String.rstrip(:unicode.characters_to_binary(Enum.reverse(buffer)), ?\s ) } | acc]
   end
 
   defp tokenize_text(line, buffer, acc, false) do
@@ -341,7 +340,7 @@ defmodule Mustache.Tokenizer do
     { [{ :text, line, :unicode.characters_to_binary(Enum.reverse(buffer)) } | acc], 0 }
   end
 
-  defp do_tokenize_text_and_count_indent([? |list], i) do
+  defp do_tokenize_text_and_count_indent([?\s |list], i) do
     do_tokenize_text_and_count_indent(list, i + 1)
   end
 
@@ -349,7 +348,7 @@ defmodule Mustache.Tokenizer do
 
   # ignore flg
 
-  defp ignore_break?([? |t], acc), do: ignore_break?(t,acc)
+  defp ignore_break?([?\s |t], acc), do: ignore_break?(t,acc)
   defp ignore_break?([?\n,?\r|_], _), do: true
   defp ignore_break?([?\n|_], _), do: true
   defp ignore_break?([], [:line_break|_]), do: true
@@ -376,7 +375,7 @@ defmodule Mustache.Tokenizer do
 
   defp head_is_line_break?([:line_break|_]), do: true
   defp head_is_line_break?(_), do: false
-  
+
   defp binary_to_atom(binary) do
     :erlang.binary_to_atom(binary, :utf8)
   end

--- a/lib/mustache/utils.ex
+++ b/lib/mustache/utils.ex
@@ -42,7 +42,7 @@ defmodule Mustache.Utils do
   def to_binary(other), do: Kernel.to_string(other)
 
   defp split_float(bin) do
-    String.to_char_list!(bin)
+    String.to_charlist(bin)
     |> :lists.reverse
     |> split_float(0, '')
   end


### PR DESCRIPTION
While attempting to use this library with Elixir 1.3.1, there were several warnings.  

The 3 commits resolve most of the warnings. Each type of warning is resolved in its own commit.

All tests are passing.